### PR TITLE
Updating description doesn't nullify title and vice versa

### DIFF
--- a/src/main/java/com/islandcollaborative/creativeexchange/controllers/PostController.java
+++ b/src/main/java/com/islandcollaborative/creativeexchange/controllers/PostController.java
@@ -102,8 +102,8 @@ public class PostController {
     @PutMapping("/posts/{postId}")
     public RedirectView updatePosts(@PathVariable long postId, String text, String title) {
         Post post = postRepository.getOne(postId);
-        post.setText(text);
-        post.setTitle(title);
+        if (text != null && !text.isBlank()) post.setText(text);
+        if (title != null && !title.isBlank()) post.setTitle(title);
         postRepository.save(post);
         return new RedirectView("/posts/" + postId + "/edit");
     }


### PR DESCRIPTION
- [x] Added check to `PUT /posts/{postId}` route to check that a property is non-null and non-empty before setting it to the post entity.